### PR TITLE
[dw-free:#1194] Add background-color to footer in tropo-purple

### DIFF
--- a/htdocs/scss/skins/tropo/tropo-purple.scss
+++ b/htdocs/scss/skins/tropo/tropo-purple.scss
@@ -15,7 +15,7 @@
  *
  */
 
-/** 
+/**
  * Dreamwidth Site Scheme
  *
  * Standard layout for Dreamwidth
@@ -152,3 +152,7 @@ $topbar-dropdown-toggle-alpha: 0.8;
 $masthead-bottom-accent-color:         $primary-color;
 
 @import "skins/tropo/tropo-base";
+
+footer {
+    background-color: $soft-accent-color;
+}


### PR DESCRIPTION
This reproduces the background effect from the pre-Foundation version.  Fixes dreamwidth/dw-free#1194.