### PR TITLE
Removes whitespace below icons for dw-nonfree layouts

### DIFF
--- a/styles/sundaymorning/layout.s2
+++ b/styles/sundaymorning/layout.s2
@@ -708,6 +708,7 @@ $userpic_css
 
 .entry .userpic img, .comment .userpic img {
     border: none;
+    display: block;
 }
 
 .entry-title, .comment-title {

--- a/styles/transmogrified/layout.s2
+++ b/styles/transmogrified/layout.s2
@@ -668,6 +668,7 @@ function Page::print_default_stylesheet () {
 
     .entry .userpic img, .comment .userpic img {
         border: none;
+        display:block;
     }
 
     .entry-title, .comment-title {


### PR DESCRIPTION
Changes the display type of the icon from inline to block,
which removes the extra whitespace added automatically for
baseline alignment. The layouts affected were:
-Sunday Morning
-Transmogrified

Fixes #1391