### PR TITLE
Add different formatting for unavailable commands

### DIFF
--- a/htdocs/scss/skins/tropo/tropo-purple.scss
+++ b/htdocs/scss/skins/tropo/tropo-purple.scss
@@ -83,6 +83,10 @@ $list-side-margin:                      1em;
 // we want to base these on $body-font-color rather than the random variables they're based on
 $blockquote-font-color:                 tint( $body-font-color, 20% );
 
+// Explicitly enabled and disabled text
+$enabled-color:          $text-color;
+$disabled-color:         $strong-accent-color;
+
 // We use these to style anchors1
 $anchor-text-decoration:               underline;
 $anchor-font-color:                    $link-color;

--- a/htdocs/scss/skins/tropo/tropo-red.scss
+++ b/htdocs/scss/skins/tropo/tropo-red.scss
@@ -82,6 +82,10 @@ $list-side-margin:                      1em;
 // we want to base these on $body-font-color rather than the random variables they're based on
 $blockquote-font-color:                 tint( $body-font-color, 20% );
 
+// Explicitly enabled and disabled text
+$enabled-color:          $text-color;
+$disabled-color:         $strong-accent-color;
+
 // We use these to style anchors1
 $anchor-text-decoration:               underline;
 $anchor-font-color:                    $link-color;


### PR DESCRIPTION
Apply different formatting in the Admin Console for enabled and disabled
commands, to help differentiate the two.

This is the non-free part of the fix for dreamwidth/dw-free#1398

The free part will also need to be merged; it's pull request dreamwidth/dw-free#1406