### PR TITLE
Replace Dreamwidth HTTP links with HTTPS

### DIFF
--- a/bin/upgrading/en_DW.dat
+++ b/bin/upgrading/en_DW.dat
@@ -27,7 +27,7 @@ On [[date]] at [[time]] your journal was deleted. The journal deletion took plac
   
 If you made this change yourself, this email serves as a confirmation of your change.
    
-If you didn't delete your journal, your journal's security has been compromised. Please contact Support [[http://www.dreamwidth.org/support/]] to learn what steps you should take to resecure your journal.
+If you didn't delete your journal, your journal's security has been compromised. Please contact Support [[https://www.dreamwidth.org/support/]] to learn what steps you should take to resecure your journal.
 
 This letter was sent out automatically to help you keep your account secure. You can't opt-out of receiving these letters. 
 .
@@ -73,7 +73,7 @@ shop.email.comm.close<<
 
 Congratulations on your community's paid time! You can see a list of all the premium features you now have access to here:
 
-    http://www.dreamwidth.org/support/faqbrowse?faqid=4
+    https://www.dreamwidth.org/support/faqbrowse?faqid=4
 
 Thanks for supporting Dreamwidth, and for making it possible for us to 
 keep building an awesome service.
@@ -101,7 +101,7 @@ Please remember to include both the order number and the PO box number! Also, be
 
 Thank you for your purchase! You can see a list of all the premium features you'll have access to here:
 
-    http://www.dreamwidth.org/support/faqbrowse?faqid=4
+    https://www.dreamwidth.org/support/faqbrowse?faqid=4
 
 Thanks for supporting Dreamwidth, and for making it possible for us to 
 keep building an awesome service.
@@ -123,7 +123,7 @@ This email confirms your purchase from the [[sitename]] shop.  You can view your
 Thank you for your purchase! You can see a list of all the premium features 
 here:
 
-    http://www.dreamwidth.org/support/faqbrowse?faqid=4
+    https://www.dreamwidth.org/support/faqbrowse?faqid=4
 
 Thanks for supporting Dreamwidth, and for making it possible for us to 
 keep building an awesome service.
@@ -137,7 +137,7 @@ shop.email.email.close<<
 
 We look forward to having you on the site! You can see a list of all the premium features you'll have access to here:
 
-    http://www.dreamwidth.org/support/faqbrowse?faqid=4
+    https://www.dreamwidth.org/support/faqbrowse?faqid=4
 
 .
 
@@ -145,7 +145,7 @@ shop.email.user.close<<
 
 Congratulations on your paid time! You can see a list of all the premium features you now have access to here:
 
-    http://www.dreamwidth.org/support/faqbrowse?faqid=4
+    https://www.dreamwidth.org/support/faqbrowse?faqid=4
 
 Thanks for supporting Dreamwidth, and for making it possible for us to 
 keep building an awesome service.
@@ -196,7 +196,7 @@ here:
 If you don't want to renew your community's paid account, don't worry -- it'll still be there for you to use. You and your community members just
 won't have access to all of the paid account features. You can see a list of those paid account features here:
 
-  http://www.dreamwidth.org/support/faqbrowse?faqid=4
+  https://www.dreamwidth.org/support/faqbrowse?faqid=4
 
 [[sitename]] is supported entirely by your payments. We aren't owned
 by a corporate conglomerate, we haven't taken any venture capital from
@@ -232,7 +232,7 @@ another three days if you don't renew. If that happens, you'll still
 be able to use it; you just won't have access to our paid features
 anymore. You can see a list of those paid features here:
 
-    http://www.dreamwidth.org/support/faqbrowse?faqid=4
+    https://www.dreamwidth.org/support/faqbrowse?faqid=4
 
 Thanks for supporting Dreamwidth, and for making it possible for us
 to build an awesome online home.
@@ -286,7 +286,7 @@ still keep using the site. You just won't have access to all of the
 paid account features. You can see a list of those paid account features
 here:
 
-  http://www.dreamwidth.org/support/faqbrowse?faqid=4
+  https://www.dreamwidth.org/support/faqbrowse?faqid=4
 
 [[sitename]] is supported entirely by your payments. We aren't owned
 by a corporate conglomerate, we haven't taken any venture capital from
@@ -322,7 +322,7 @@ another three days if you don't renew. If that happens, you'll still
 be able to use it; you just won't have access to our paid features
 anymore. You can see a list of those paid features here:
 
-    http://www.dreamwidth.org/support/faqbrowse?faqid=4
+    https://www.dreamwidth.org/support/faqbrowse?faqid=4
 
 Thanks for supporting Dreamwidth, and for making it possible for us
 to build an awesome online home.
@@ -457,9 +457,9 @@ tropo.search.siteuser=Site &amp; User
 
 widget.createaccountentercode.getcode=If you do not have an account creation code, you can find or request one in <?ljcomm dw_codesharing ljcomm?>.
 
-widget.createaccountentercode.info=To create a new account, enter an account creation code (<a href="http://www.dreamwidth.org/support/faqbrowse?faqid=105">Why?</a>):
+widget.createaccountentercode.info1=To create a new account, enter an account creation code (<a href="https://www.dreamwidth.org/support/faqbrowse?faqid=105">Why?</a>):
 
-widget.importchoosesource.disabled=Starting a new import is temporarily disabled due to high volume. Existing imports will still be processed in the order they were submitted. New imports will be available again once the import queue clears out a little more. For more information, see <a href="http://dw-maintenance.dreamwidth.org">dw_maintenance</a>.
+widget.importchoosesource.disabled1=Starting a new import is temporarily disabled due to high volume. Existing imports will still be processed in the order they were submitted. New imports will be available again once the import queue clears out a little more. For more information, see <a href="https://dw-maintenance.dreamwidth.org">dw_maintenance</a>.
 
 widget.shopcart.paymentmethod.creditcardpp=[N/A]
 

--- a/etc/config-local.pl
+++ b/etc/config-local.pl
@@ -79,7 +79,7 @@
     # if you define these, little help bubbles appear next to common
     # widgets to the URL you define:
     %HELPURL = (
-        paidaccountinfo => "http://www.dreamwidth.org/support/faqbrowse.bml?faqid=4",
+        paidaccountinfo => "https://www.dreamwidth.org/support/faqbrowse.bml?faqid=4",
     );
 
     # Configuration for suggestions community & adminbot

--- a/etc/staff.yaml
+++ b/etc/staff.yaml
@@ -1,7 +1,7 @@
 -   name: Dreamwidth Studios, LLC's Owners
     people:
         -   name: Denise Paolucci
-            img: http://www.dreamwidth.org/userpic/256/6
+            img: https://www.dreamwidth.org/userpic/256/6
             bio:
                 - |
                     (the Suit) began working on the
@@ -22,7 +22,7 @@
                 - denise
                 - dw_biz
         -   name: Mark Smith
-            img: http://www.dreamwidth.org/userpic/257/6
+            img: https://www.dreamwidth.org/userpic/257/6
             bio:
                 - |
                     (the Geek) began volunteering with LiveJournal.com in 2001 in technical
@@ -45,7 +45,7 @@
 -   name: Dreamwidth Studios, LLC's Employees
     people:
         -   name: Afuna
-            img: http://www.dreamwidth.org/userpic/258/6
+            img: https://www.dreamwidth.org/userpic/258/6
             bio:
                 - |
                     first learned Perl as part of the Support team on LiveJournal. There, she picked
@@ -61,7 +61,7 @@
             official:
                 - fu
         -   name: MissKat
-            img: http://www.dreamwidth.org/userpic/5322645/294908
+            img: https://www.dreamwidth.org/userpic/5322645/294908
             bio:
                 - |
                     heads up the Dreamwidth Support team. She specializes in facilitating
@@ -77,7 +77,7 @@
                 - misskat
                 - dw_support
         -   name: Alierak
-            img: http://www.dreamwidth.org/userpic/314317/7805
+            img: https://www.dreamwidth.org/userpic/314317/7805
             bio:
                 - |
                     is Dreamwidth's backup sysadmin on call, helping Mark wrangle servers
@@ -97,7 +97,7 @@
     note: "People who are currently working on major projects for Dreamwidth!"
     people:
         -   name: Azurelunatic
-            img: http://www.dreamwidth.org/userpic/529546/6
+            img: https://www.dreamwidth.org/userpic/529546/6
             bio:
                 - |
                     came into the LiveJournal volunteer IRC channel during one of the early
@@ -118,7 +118,7 @@
             official:
                 - dw_antispam
         -   name: ChemicalLace
-            img: http://www.dreamwidth.org/userpic/529533/6
+            img: https://www.dreamwidth.org/userpic/529533/6
             bio:
                 - |
                     is &#8531; of the Dreamwidth Support Triumvirate.  She volunteered for
@@ -131,7 +131,7 @@
             official:
                 - dw_support
         -   name: DomTheKnight
-            img: http://www.dreamwidth.org/userpic/2564/6
+            img: https://www.dreamwidth.org/userpic/2564/6
             bio:
                 - |
                     is leading the user acceptance testing team for Dreamwidth and is &#8531;
@@ -148,7 +148,7 @@
                 - dw_beta
                 - dw_support
         -   name: Jennifer Griffin
-            img: http://www.dreamwidth.org/userpic/210571/6
+            img: https://www.dreamwidth.org/userpic/210571/6
             bio:
                 - |
                     does Terms of Service enforcement because Mark
@@ -169,7 +169,7 @@
             official:
                 - dw_tos
         -   name: Audra Johnson
-            img: http://www.dreamwidth.org/userpic/261/6
+            img: https://www.dreamwidth.org/userpic/261/6
             bio:
                 - |
                     (the Information Architect) has insatiable needs to collate and organize
@@ -187,7 +187,7 @@
                 - dw_wiki
                 - dw_styles
         -   name: Andrea Nall
-            img: http://www.dreamwidth.org/userpic/262/6
+            img: https://www.dreamwidth.org/userpic/262/6
             bio:
                 - |
                     has been working on the Dreamwidth project since
@@ -204,7 +204,7 @@
                     time? Between staring at pages of code for hours on end and school? If only
                     she didn't have to sleep.
         -   name: Pau Amma
-            img: http://www.dreamwidth.org/userpic/263/6
+            img: https://www.dreamwidth.org/userpic/263/6
             bio:
                 - |
                     has been volunteering for LiveJournal since early 2005 and
@@ -224,7 +224,7 @@
                     His alignment shifts randomly between Useful Evil, Chaotic
                     Punny, and Ergative Absolutive.
         -   name: Deborah
-            img: http://www.dreamwidth.org/userpic/5456520/37793
+            img: https://www.dreamwidth.org/userpic/5456520/37793
             bio:
                 - |
                     co-leads the accessibility team. She spends her time writing accessibility
@@ -235,7 +235,7 @@
             official:
                 - dw_accessibility
         -   name: Ricky Buchanan
-            img: http://www.dreamwidth.org/userpic/529540/6
+            img: https://www.dreamwidth.org/userpic/529540/6
             bio:
                 - |
                     continues her fight for an internet she can actually use by leading the
@@ -248,7 +248,7 @@
             official:
                 - dw_accessibility
         -   name: Sarah
-            img: http://www.dreamwidth.org/userpic/529553/6
+            img: https://www.dreamwidth.org/userpic/529553/6
             bio:
                 - |
                     serves as Dreamwidth's executive assistant, which involves

--- a/htdocs/index.bml
+++ b/htdocs/index.bml
@@ -156,7 +156,7 @@ HTML
             {
                 name => 'community',
                 items => [
-                    [ 'http://dw-news.dreamwidth.org/', 'site_news' ],
+                    [ 'https://dw-news.dreamwidth.org/', 'site_news' ],
                     [ '/latest', 'latest_things', 'footnote' ],
                     [ '/random', 'random_journal', 'footnote' ],
                     [ '/community/random', 'random_community', 'footnote' ],
@@ -172,7 +172,7 @@ HTML
             },
         );
 
-        push @{$columns[1]->{items}}, [ 'http://dw-codesharing.dreamwidth.org/', 'codeshare' ]
+        push @{$columns[1]->{items}}, [ 'https://dw-codesharing.dreamwidth.org/', 'codeshare' ]
             if $LJ::USE_ACCT_CODES;
 
         foreach my $column ( @columns ) {

--- a/htdocs/site/bot.bml
+++ b/htdocs/site/bot.bml
@@ -24,7 +24,7 @@ body<=
 
 <p>We welcome people writing bots and clients that make use of our APIs and do cool things with our data! In order to balance the needs of client/bot authors and the needs of our users, though, we've set forth some general guidelines that bot authors should keep in mind.</p>
 
-<p>If you have a question that isn't covered here, please <a href='http://www.dreamwidth.org/support/submit'>contact us</a> with details about your planned use. We're happy to work with you to do neat projects, including fixing problems on our end and making more public data available through our APIs. Just ask.</p>
+<p>If you have a question that isn't covered here, please <a href='https://www.dreamwidth.org/support/submit'>contact us</a> with details about your planned use. We're happy to work with you to do neat projects, including fixing problems on our end and making more public data available through our APIs. Just ask.</p>
 
 <h2>General Guidelines</h2><br />
 

--- a/htdocs/site/brand.bml
+++ b/htdocs/site/brand.bml
@@ -27,7 +27,7 @@ body<=
 
 <p>In order to protect our users from confusion and to protect our identity and reputation, we have set forth guidelines for using our name and our logos. This applies to anyone who would like to run a production site using any of the code developed or maintained by Dreamwidth Studios, LLC, as well as to anyone who would like to write a client or tool that interfaces with Dreamwidth code.</p>
 
-<p>These are basic guidelines. If you have a question that isn't covered here, please <a href='http://www.dreamwidth.org/support/submit'>contact us</a> with details about your planned use. We are happy to answer any questions you might have, and we are more than willing to grant express written permission for the use of any of our service marks in most cases as long as we feel there's no chance of causing confusion among our users.</p>
+<p>These are basic guidelines. If you have a question that isn't covered here, please <a href='https://www.dreamwidth.org/support/submit'>contact us</a> with details about your planned use. We are happy to answer any questions you might have, and we are more than willing to grant express written permission for the use of any of our service marks in most cases as long as we feel there's no chance of causing confusion among our users.</p>
 
 <p>In all cases, the guiding principle in any use of our brand and/or service marks should be to avoid any possibility for reasonable confusion. An average person should never be able to accidentally mistake your use of our brand and/or mark as an official or sponsored use.</p>
 
@@ -39,7 +39,7 @@ body<=
 <li><b>Client</b>: A program (either downloadable or running via internet) that is designed to interface and interact with the Dreamwidth codebase.</li>
 <li><b>Production site</b>: A publicly-accessible website that accepts users, whether it uses open account creation or not, and whether it accepts money for services or not.</li>
 <li><b>Open Source license</b>: A license approved by the <a href='http://www.opensource.org/licenses'>Open Source Initiative</a> as meeting the definition of 'open source'. Dreamwidth Studios' code is released under the user's choice of the Artistic License or the GNU General Public License.</li>
-<li><b>Trademark</b>: 'Dreamwidth', 'Dreamwidth Studios', <a href='http://s.dreamwidth.org/img/tropo-red/dw_logo.png'>Dreamwidth logo</a>, the <a href='http://s.dreamwidth.org/img/tropo-red/icon_menu_swirl.png'>Dreamwidth swirl</a>, and the <a href='http://s.dreamwidth.org/img/nouserpic.png'>swirled 'd'</a> are all trademarks of Dreamwidth Studios, LLC (registration pending).</li>
+<li><b>Trademark</b>: 'Dreamwidth', 'Dreamwidth Studios', <a href='https://s.dreamwidth.org/img/tropo-red/dw_logo.png'>Dreamwidth logo</a>, the <a href='https://s.dreamwidth.org/img/tropo-red/icon_menu_swirl.png'>Dreamwidth swirl</a>, and the <a href='https://s.dreamwidth.org/img/nouserpic.png'>swirled 'd'</a> are all trademarks of Dreamwidth Studios, LLC (registration pending).</li>
 </ul><br />
 
 <h2>General Guidelines</h2><br />
@@ -50,7 +50,7 @@ body<=
   <li>Clearly state, on the splash page or login screen of your client, that your client is not created by or sponsored by Dreamwidth Studios, LLC;</li>
   <li>Clearly state, in the credits or About page of your client, that Dreamwidth's trademarks are owned by Dreamwidth Studios, LLC;</li>
   <li>Include your name and your contact information in a prominent place in your client, indicating that people should contact you and not Dreamwidth Studios, LLC with questions about the client;</li>
-  <li>Provide a prominent link to <a href='http://www.dreamwidth.org'>www.dreamwidth.org</a> in your client, such as by saying 'For use with <a href='http://www.dreamwidth.org'>Dreamwidth Studios</a>';</li>
+  <li>Provide a prominent link to <a href='https://www.dreamwidth.org'>www.dreamwidth.org</a> in your client, such as by saying 'For use with <a href='https://www.dreamwidth.org'>Dreamwidth Studios</a>';</li>
   <li>Avoid giving the impression, both in your client and in your end-user support, that you are affiliated with or speak for Dreamwidth Studios, LLC.</li></ul></li>
  <li>You <b>may not</b> use, alter, or adapt our trademarks for use in your primary logo or identity without our express written permission. You <em>may</em> use, alter, or adapt our trademarks for use in your client's icons, as long as you follow all of the above rules.</li>
  <li>If you want to do something that doesn't comply with the above rules (such as making a closed-source application), contact us to discuss it.</li>
@@ -63,30 +63,30 @@ body<=
  <li>The site name is only capitalized at the beginning: <em>Dreamwidth</em>, not <em>DreamWidth</em>.</li>
  <li>You <b>may not</b> use the site name in merchandise, including but not limited to t-shirts, stickers, mugs, or jewelry, without our express written permission.</li>
  <li>You <b>may not</b> use the site name in any way that indicates or implies our sponsorship, endorsement, or approval, without our express written permission.</li>
- <li>You <b>may not</b> use the site name in conjunction with any content that is explicit, hateful, discriminatory, exclusionary, or that violates our <a href='http://www.dreamwidth.org/legal/principles'>Guiding Principles</a>.</li>
+ <li>You <b>may not</b> use the site name in conjunction with any content that is explicit, hateful, discriminatory, exclusionary, or that violates our <a href='https://www.dreamwidth.org/legal/principles'>Guiding Principles</a>.</li>
 </ul><br />
 
 <h2>Site Logo</h2><br />
 <ul>
- <li>You <em>may</em> use our graphic trademarks in a journalistic fashion -- for instance, if you are making a blog post or writing a newspaper article about Dreamwidth Studios. We ask that you include, under each use of our trademark, a notice: <em>&copy; Dreamwidth Studios, LLC</em>. Please link the words 'Dreamwidth Studios, LLC' to the URL <a href='http://www.dreamwidth.org'>www.dreamwidth.org</a>.</li>
+ <li>You <em>may</em> use our graphic trademarks in a journalistic fashion -- for instance, if you are making a blog post or writing a newspaper article about Dreamwidth Studios. We ask that you include, under each use of our trademark, a notice: <em>&copy; Dreamwidth Studios, LLC</em>. Please link the words 'Dreamwidth Studios, LLC' to the URL <a href='https://www.dreamwidth.org'>www.dreamwidth.org</a>.</li>
  <li>You <em>may</em> use these trademarks in banners, icons, and graphics intended to positively promote the use and adoption of Dreamwidth Studios.</li>
  <li>You <b>may not</b> use any of these trademarks in merchandise, including but not limited to t-shirts, stickers, mugs, or jewelry, without our express written permission.</li>
  <li>You <b>may not</b> use any of these trademarks in any way that indicates or implies our sponsorship, endorsement, or approval, without our express written permission.</li>
  <li>You <b>may not</b> use any of our trademarks in banners, icons, and graphics if doing so would cause a reasonable person to mistake your use as speaking for or representing Dreamwidth Studios, LLC. (For instance, in an icon captioned 'Dreamwidth Staff'.)</li>
- <li>You <b>may not</b> use our trademarks in conjunction with any content that is explicit, hateful, discriminatory, exclusionary, or that violates our <a href='http://www.dreamwidth.org/legal/principles'>Guiding Principles</a>.</li>
+ <li>You <b>may not</b> use our trademarks in conjunction with any content that is explicit, hateful, discriminatory, exclusionary, or that violates our <a href='https://www.dreamwidth.org/legal/principles'>Guiding Principles</a>.</li>
 </ul><br />
 
 <h2>Site Design</h2><br />
  <ul><li>The default site design visible on www.dreamwidth.org, known as 'Tropospherical Red', is our default visual identity. Because of this, and because of the potential for confusion, you should refrain from using these design elements in these colors for your client's website, without our express written permission.</li>
  <li>The client homepage -- whether the tool itself is web-based or the page is hosting a downloadable application -- must clearly indicate that the client is not created by, affiliated with, or sponsored by Dreamwidth Studios, LLC.</li>
  <li>The client homepage should include your name and contact information in a prominent place, and indicate that people should contact you and not Dreamwidth Studios, LLC with questions about your client.</li>
- <li>The client homepage should not contain any content that is explicit, hateful, discriminatory, exclusionary, or that violates our <a href='http://www.dreamwidth.org/legal/principles'>Guiding Principles</a>.</li>
+ <li>The client homepage should not contain any content that is explicit, hateful, discriminatory, exclusionary, or that violates our <a href='https://www.dreamwidth.org/legal/principles'>Guiding Principles</a>.</li>
  </ul><br />
 
 <h2>Source Code</h2><br />
  <ul><li>The <a href='https://github.com/dreamwidth/'>source code</a> for Dreamwidth Studios is based on code developed and maintained by LiveJournal.com. Code in the dw-free repository authored by LiveJournal is released under the GNU General Public License. Code in the dw-free repository authored by Dreamwidth Studios, LLC is dual-released under the GPL and Artistic Licenses.</li>
  <li>Code in the dw-nonfree repository is source-available but not Open Source. You may not use code from the dw-nonfree repository to run a production site. You may only use code from the dw-nonfree repository in a development environment for the purposes of improving the source code. If your development environment is publicly web-accessible, you may only use code from the dw-nonfree repository with our express written permission.</li>
- <li>If you are running a production site based on the Dreamwidth code, please let us know! We would like to add a link to your site to our <a href='http://www.dreamwidth.org/site/opensource'>Open Source</a> page.</li>
+ <li>If you are running a production site based on the Dreamwidth code, please let us know! We would like to add a link to your site to our <a href='https://www.dreamwidth.org/site/opensource'>Open Source</a> page.</li>
 </ul><br />
 
 

--- a/htdocs/site/policy.bml
+++ b/htdocs/site/policy.bml
@@ -29,17 +29,17 @@ body<=
 
 <p>We believe in providing our users with the maximum amount of free expression as permitted by United States law, with the exceptions of actions we choose to take to protect the health of the service (such as by removing spam) and actions we choose to take to safeguard the privacy and safety of others.</p>
 
-<p>We know that any conflict between two people has the potential to become heated, and that once a conflict becomes heated, it is often very difficult for us to determine what the best and most ethical course of action should be. We are committed to upholding our <a href='http://www.dreamwidth.org/legal/principles'>Guiding Principles</a>, and we will work with you to determine the best course of action in any given situation.</p>
+<p>We know that any conflict between two people has the potential to become heated, and that once a conflict becomes heated, it is often very difficult for us to determine what the best and most ethical course of action should be. We are committed to upholding our <a href='https://www.dreamwidth.org/legal/principles'>Guiding Principles</a>, and we will work with you to determine the best course of action in any given situation.</p>
 
 <p>We will provide as much information about our policies and their enforcement as we can while still respecting the privacy of our users. While this means that we will never release details about a specific conflict without the express permission of all parties involved, we are always willing to answer general questions about our policies.</p>
 
-<dl><dt><a href='http://www.dreamwidth.org/legal/tos'>Terms of Service</a></dt>
+<dl><dt><a href='https://www.dreamwidth.org/legal/tos'>Terms of Service</a></dt>
 <dd>The Terms of Service governing all usage of the site.</dd></dl>
 
-<dl><dt><a href='http://www.dreamwidth.org/legal/privacy'>Privacy Policy</a></dt>
+<dl><dt><a href='https://www.dreamwidth.org/legal/privacy'>Privacy Policy</a></dt>
 <dd>Our Privacy Policy, which explains how we use any information you provide us.</dd></dl>
 
-<dl><dt><a href='http://www.dreamwidth.org/support/faqbrowse?faqid=80'>Reporting a Terms of Service Violation</a></dt>
+<dl><dt><a href='https://www.dreamwidth.org/support/faqbrowse?faqid=80'>Reporting a Terms of Service Violation</a></dt>
 <dd>How to report a violation of our Terms of Service agreement, or seek clarification on any of our policies.</dd></dl>
 
 

--- a/views/legal/dmca.tt
+++ b/views/legal/dmca.tt
@@ -40,7 +40,7 @@
 
 <li>Notifications must specifically identify the copyrighted work being infringed upon. For instance, if the work is a published book, provide the title, author, and ISBN; if the work is a magazine article, provide the title, author, magazine name, and magazine issue; if the work is available on the Internet, provide the URL of the work.</li>
 
-<li>Notifications must specifically include the URL where the work is being infringed upon [% site.nameshort %]'s servers. For us to be able to reasonably identify the material, you must provide us with the complete URL, not a link to the entire journal. For instance, instead of http://username.[% site.domain %] (a link to the entire journal), provide http://username.[% site.domain %]/123.html (a link to the specific entry).</li>
+<li>Notifications must specifically include the URL where the work is being infringed upon [% site.nameshort %]'s servers. For us to be able to reasonably identify the material, you must provide us with the complete URL, not a link to the entire journal. For instance, instead of https://username.[% site.domain %] (a link to the entire journal), provide https://username.[% site.domain %]/123.html (a link to the specific entry).</li>
 
 <li>Notifications must include sufficient information for us to contact you, including your address, your telephone number, and your email address.</li>
 


### PR DESCRIPTION
In preparation for enabling HTTPS everywhere, it would be nice if all the hardcoded links are HTTPS rather than HTTP.

Along with the corresponding request at dreamwidth/dw-free, this fixes dreamwidth/dw-free#1006.