### PR TITLE
Remove references to dwscoalition.org

### DIFF
--- a/htdocs/site/suggest.bml
+++ b/htdocs/site/suggest.bml
@@ -7,9 +7,9 @@
 # simple opinion poll to easily get the opinions of the readers. In
 # addition to posting a public entry to the comm, it also posts an
 # admin-only entry with the text of the suggestion formatted for autopost
-# to Bugzilla, which will not only save some time in opening up the bug,
-# but also ensure that the text of the suggestion is preserved if the
-# poster of the entry decides to delete it after getting some 
+# to GitHub Issues, which will not only save some time in opening up the
+# bug, but also ensure that the text of the suggestion is preserved if the
+# poster of the entry decides to delete it after getting some
 # disagreeing comments.
 #
 # Authors:
@@ -109,46 +109,42 @@ body<=
             # for the suggestion. we can't use $suggestion that we built,
             # because we need to use a different escaping function, but
             # that's okay, because we want to format this a little
-            # differently anyway. The Bugzilla template is going to need
-            # some messing with at the time of posting, but I'd rather do
-            # that manually at the time of posting than try to fuss with it
-            # here.
-    
-            my ( $bugzilla_subject, $bugzilla_desc, $bugzilla_post );
-    
-            $bugzilla_subject = LJ::eurl( $POST{title} );
-    
-            $bugzilla_desc .= "Summary%3A%0D%0A%0D%0A";
-            $bugzilla_desc .= LJ::eurl( $POST{summary} );
-            $bugzilla_desc .= "%0D%0A%0D%0ADescription%3A%0D%0A%0D%0A";
-            $bugzilla_desc .= LJ::eurl( $POST{description} );
-            $bugzilla_desc .= "%0D%0A%0D%0ASuggested by%3A%0D%0A%0D%0A";
-            $bugzilla_desc .= LJ::eurl( $remote->user );
-    
-            $bugzilla_post .= "To post this entry to Bugzilla, use this link and change any of the fields as appropriate:<br /><br />&nbsp;&nbsp;&nbsp;<a href='";
-    
-            # oh my god bugzilla makes ugly URLs:
-            $bugzilla_post .= "http://bugs.dwscoalition.org/enter_bug.cgi?assigned_to=&blocked=&bug_file_loc=http%3A%2F%2F&bug_severity=enhancement&bug_status=NEW&comment=" . $bugzilla_desc . "&contenttypeentry=&contenttypemethod=autodetect&contenttypeselection=text%2Fplain&data=&dependson=&description=&flag_type-1=X&flag_type-10=X&flag_type-11=X&flag_type-2=X&flag_type-3=X&flag_type-5=X&flag_type-7=X&form_name=enter_bug&keywords=from-suggestions&op_sys=All&priority=P-&product=Dreamwidth%20Development&qa_contact=&rep_platform=All&short_desc=" . $bugzilla_subject . "&target_milestone=-undecided-&version=1.0";
-    
-            $bugzilla_post .= "'>Post '$POST{title}' to Bugzilla</a>.<br /><br />Once you do, retag both this entry and the public entry it belongs with.";
-    
+	    # differently anyway.
+
+            my ( $ghi_subject, $ghi_desc, $ghi_post );
+
+            $ghi_subject = LJ::eurl( $POST{title} );
+
+            $ghi_desc .= "Summary%3A%0D%0A%0D%0A";
+            $ghi_desc .= LJ::eurl( $POST{summary} );
+            $ghi_desc .= "%0D%0A%0D%0ADescription%3A%0D%0A%0D%0A";
+            $ghi_desc .= LJ::eurl( $POST{description} );
+            $ghi_desc .= "%0D%0A%0D%0ASuggested by%3A%0D%0A%0D%0A";
+            $ghi_desc .= LJ::eurl( $remote->user );
+
+            $ghi_post .= "<p>To post this entry to GitHub, use this link and change any of the fields as appropriate:</p><blockquote><p><a href='";
+
+            $ghi_post .= "https://github.com/dreamwidth/dw-free/issues/new?body=" . $ghi_desc . "&title=" . $ghi_subject;
+
+            $ghi_post .= "'>Post '$POST{title}' to GitHub Issues</a>.</p></blockquote><p>Once you do, retag both this entry and the public entry it belongs with.</p>";
+
             # and we post that post to the community. (the suggestions_bot
             # account should have unmoderated posting ability, so that the
             # post is posted directly to the comm without having to go 
             # through moderation.) for this post, we tag it as 
             # "admin: unmigrated", so the suggestions maintainer can find
-            # any/all unposted bugzilla links.
+            # any/all unposted GitHub links.
 
             # get the user's timzeone and put it into +/-0800 format
             # if we can't figure it out, then just guess based on suggestions bot
             my ( $remote_tz_sign, $remote_tz_offset ) = ( $remote->timezone =~ m/([+|-])?(\d+)/ );
             my $remote_tz = defined $remote_tz_offset ? sprintf( "%s%02d00", $remote_tz_sign || "+", $remote_tz_offset ) : "guess";
 
-            my $bugzillapost = LJ::Protocol::do_request( 'postevent', {
+            my $ghipost = LJ::Protocol::do_request( 'postevent', {
                 'ver'             => $LJ::PROTOCOL_VER,
                 'username'        => $suggestions_bot->user,
                 'subject'         => $POST{title},
-                'event'           => $bugzilla_post,
+                'event'           => $ghi_post,
                 'usejournal'      => $destination->user,
                 'security'        => 'private',
                 'usejournal_okay' => 1,

--- a/htdocs/site/suggest.bml
+++ b/htdocs/site/suggest.bml
@@ -15,7 +15,7 @@
 # Authors:
 #      Denise Paolucci <denise@dreamwidth.org>
 #
-# Copyright (c) 2009 by Dreamwidth Studios, LLC.
+# Copyright (c) 2009-2016 by Dreamwidth Studios, LLC.
 #
 # This program is NOT free software or open-source; you can use it as an
 # example of how to implement your own site-specific extensions to the

--- a/htdocs/site/suggest.bml
+++ b/htdocs/site/suggest.bml
@@ -2,8 +2,8 @@
 #
 # site/suggest.bml
 #
-# Simple form suggestion generator that will take input, process it, and 
-# post it to a community's moderation queue.  The post will include a 
+# Simple form suggestion generator that will take input, process it, and
+# post it to a community's moderation queue.  The post will include a
 # simple opinion poll to easily get the opinions of the readers. In
 # addition to posting a public entry to the comm, it also posts an
 # admin-only entry with the text of the suggestion formatted for autopost
@@ -104,7 +104,7 @@ body<=
 
         if ( $journalpost ) {
 
-            # having built the post for public display, we now do 
+            # having built the post for public display, we now do
             # a second post containing the link to create the new bug
             # for the suggestion. we can't use $suggestion that we built,
             # because we need to use a different escaping function, but
@@ -130,8 +130,8 @@ body<=
 
             # and we post that post to the community. (the suggestions_bot
             # account should have unmoderated posting ability, so that the
-            # post is posted directly to the comm without having to go 
-            # through moderation.) for this post, we tag it as 
+            # post is posted directly to the comm without having to go
+            # through moderation.) for this post, we tag it as
             # "admin: unmigrated", so the suggestions maintainer can find
             # any/all unposted GitHub links.
 
@@ -211,7 +211,7 @@ body<=
 
 
 
-    # Build the suggestions form. All fields required. 
+    # Build the suggestions form. All fields required.
 
     $ret .= "<p>Have a way to make Dreamwidth better? This is where you submit it! Filling out this form will send an entry to the moderation queue of the " . $destination->ljuser_display . " community. You may want to <a href='$LJ::SITEROOT/search?user=" . $destination->user . "'>search the community</a> before making a new suggestion. If your suggestion hasn't been submitted before, it will be posted for discussion, voting, and possible implementation.</p>";
     $ret .= "<p>Anyone can submit a suggestion. Other members of the Dreamwidth community will consider the suggestion, make comments for improvement to the suggestion, and talk about its benefits and drawbacks. The entry will also include a poll for people to register their like or dislike for an idea.</p>";
@@ -222,7 +222,7 @@ body<=
 
     # Title:
     $ret .= "<h2>Title</h2><p>This will be the title of your entry. (Be as specific as possible.)</p>";
-    $ret .= LJ::html_text( { 
+    $ret .= LJ::html_text( {
                             name => 'title',
                             size => 60,
                             maxlength => 100,
@@ -231,7 +231,7 @@ body<=
 
     # Area (for tag cues)
     $ret .= "<h2>Area</h2><p>The area of the site your suggestion is about. (e.g.: tags, crossposting, styles, entries, etc)</p>";
-    $ret .= LJ::html_text( { 
+    $ret .= LJ::html_text( {
                             name => 'area',
                             size => 60,
                             maxlength => 100,
@@ -241,7 +241,7 @@ body<=
 
     # Summary:
     $ret .= "<h2>Summary</h2><p>A short paragraph summarizing your suggestion.</p>";
-    $ret .= LJ::html_textarea( { 
+    $ret .= LJ::html_textarea( {
                                 name => 'summary',
                                 rows => 3,
                                 cols => 100,
@@ -252,7 +252,7 @@ body<=
 
     # Full description:
     $ret .= "<h2>Full Description</h2><p>The full description of your idea. Be as specific and detailed as you can. Tell us what issue or area your suggestion is intended to improve, why you think your specific suggestion is the best solution, what problems or drawbacks your suggestion might have if it's implemented, and if there are any other ways you can think to accomplish what you'd like to improve that could also be considered. The more detail you provide, the better chances your suggestion has of being implemented.</p>";
-    $ret .= LJ::html_textarea( { 
+    $ret .= LJ::html_textarea( {
                                 name => 'description',
                                 rows => 15,
                                 cols => 100,
@@ -288,10 +288,10 @@ head<=
 <?_code
 {
     use strict;
-    
+
     LJ::set_active_resource_group( 'jquery' );
     LJ::need_res( { group => 'jquery' }, 'js/jquery/jquery.autogrow-textarea.js' );
-    
+
 }
 _code?>
 <=head

--- a/htdocs/stc/syndicateme.css
+++ b/htdocs/stc/syndicateme.css
@@ -2,7 +2,7 @@
  * syndicateme style from OSWD site:
  *   http://www.oswd.org/design/information/id/3621
  *
- * modified by Mark Smith <mark@dwscoalition.org>
+ * modified by Mark Smith <mark@dreamwidth.org>
  *
  * */
 

--- a/views/misc/about.tt
+++ b/views/misc/about.tt
@@ -26,7 +26,7 @@ Dreamwidth Studios is based upon the <a href="http://www.livejournal.com">LiveJo
 </p>
 
 <p> 
-Our development community is already healthy and thriving. We've got room for everyone to contribute, whether you've just learned how to say "hello world" or you've been programming for thirty years. Check out our <a href="http://bugs.dwscoalition.org">bug tracker</a> for information on what projects we have open, and our <a href="http://wiki.dwscoalition.org/notes/Category:Development">Development</a> wiki category for useful getting-started notes. 
+Our development community is already healthy and thriving. We've got room for everyone to contribute, whether you've just learned how to say "hello world" or you've been programming for thirty years. Check out our <a href="https://github.com/dreamwidth/dw-free/issues">bug tracker</a> for information on what projects we have open, and our <a href="http://wiki.dreamwidth.net/notes/Category:Development">Development</a> wiki category for useful getting-started notes. 
 </p>
 
 <h1>Open expression:</h1>
@@ -48,7 +48,7 @@ We will remain third-party-advertising-free. We believe it's possible to run a s
 </p>
 
 <p>
-To learn more about our business operations, check out our <a href="http://wiki.dwscoalition.org/notes/Category:Dreamwidth.org">Dreamwidth.org</a> wiki pages.
+To learn more about our business operations, check out our <a href="http://wiki.dreamwidth.net/notes/Category:Dreamwidth.org">Dreamwidth.org</a> wiki pages.
 </p>
 
 
@@ -60,4 +60,4 @@ To learn more about our business operations, check out our <a href="http://wiki.
 
 <h1>Learn More</h1>
 
-<p> For even more information, you can read our <a href="http://wiki.dwscoalition.org/notes/">Dreamwidth wiki</a>. We'd also love to hear from you in our irc channel: irc.freenode.net (port 6667), channel #dreamwidth. </p>
+<p> For even more information, you can read our <a href="http://wiki.dreamwidth.net/notes/">Dreamwidth wiki</a>. We'd also love to hear from you in our irc channel: irc.freenode.net (port 6667), channel #dreamwidth. </p>


### PR DESCRIPTION
Builds on #108, since that removes references to dwscoalition.org from the suggestions page; this PR completes the job.