### PR TITLE
update image link to use HTTPS

### DIFF
--- a/views/legal/diversity.tt
+++ b/views/legal/diversity.tt
@@ -85,4 +85,4 @@ pageviews. You're not demographic groups. You're people.</p>
 <p>Come dream with us.</p>
 <br />
 <p style="float:right; text-align:right;"><a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/">
-<img alt="Creative Commons BY-SA 3.0" style="border-width: 0;" src="http://i.creativecommons.org/l/by-sa/3.0/us/88x31.png" /></a><br /><em>This document is usable under a Creative Commons 3.0 BY-SA license.</em></p>
+<img alt="Creative Commons BY-SA 3.0" style="border-width: 0;" src="https://licensebuttons.net/l/by-sa/3.0/us/88x31.png" /></a><br /><em>This document is usable under a Creative Commons 3.0 BY-SA license.</em></p>


### PR DESCRIPTION
This is an easy fix - the old link was already redirecting to this new link that uses HTTPS.

Fixes dreamwidth/dw-free#2071.