### PR TITLE
Remove non-standard form control styling from non-foundation site skins

### DIFF
--- a/htdocs/stc/tropo/tropo-purple.css
+++ b/htdocs/stc/tropo/tropo-purple.css
@@ -537,15 +537,6 @@ hr.hr {
     color: #7e27c1;
     background-color: #7e27c1;
 }
-input.text,
-textarea.text,
-select.select,
-.autocomplete_container {
-    background: #fff url("/img/input-bg.gif") repeat-x 0 -1px;
-    border: 1px solid #bbb;
-    border-top: 1px solid #999;
-    border-left: 1px solid #999;
-}
 .appwidget .more-link {
     color: #7e27c1 !important;
     background: url('/img/arrow-double-black.gif') no-repeat 0 60%;
@@ -562,12 +553,6 @@ select.select,
 }
 .helper {
     color: #666;
-}
-
-/* Quick Reply table */
-
-#qrformdiv table {
-    border: 1px solid #999;
 }
 
 /* MonthPage */

--- a/htdocs/stc/tropo/tropo-red.css
+++ b/htdocs/stc/tropo/tropo-red.css
@@ -547,15 +547,6 @@ hr.hr {
     color: #c1272d;
     background-color: #c1272d;
 }
-input.text,
-textarea.text,
-select.select,
-.autocomplete_container {
-    background: #fff url("/img/input-bg.gif") repeat-x 0 -1px;
-    border: 1px solid #bbb;
-    border-top: 1px solid #999;
-    border-left: 1px solid #999;
-}
 .appwidget .more-link {
     color: #c1272d !important;
     background: url('/img/arrow-double-black.gif') no-repeat 0 60%;
@@ -572,12 +563,6 @@ select.select,
 }
 .helper {
     color: #666;
-}
-
-/* Quick Reply table */
-
-#qrformdiv table {
-    border: 1px solid #999;
 }
 
 /* MonthPage */


### PR DESCRIPTION
This is a companion PR to https://github.com/dreamwidth/dw-free/pull/2513, since the tropo themes aren't in dw-free. 