### PR TITLE
[#2555] Foundation usage: topbar-height has to be in rems now 

### DIFF
--- a/htdocs/scss/skins/tropo/tropo-purple.scss
+++ b/htdocs/scss/skins/tropo/tropo-purple.scss
@@ -151,7 +151,7 @@ $topbar-dropdown-link-bg:              $primary-color url($topbar-bgimage-hover)
 $topbar-menu-link-color:               $topbar-link-color;
 $topbar-menu-icon-color:               $topbar-link-color;
 
-$topbar-height: 32px;
+$topbar-height: 2rem;
 $topbar-dropdown-toggle-alpha: 0.8;
 
 $masthead-bottom-accent-color:         $primary-color;

--- a/htdocs/scss/skins/tropo/tropo-red.scss
+++ b/htdocs/scss/skins/tropo/tropo-red.scss
@@ -150,7 +150,7 @@ $topbar-dropdown-link-bg:              $soft-accent-color url($topbar-bgimage-ho
 $topbar-menu-link-color:               $topbar-link-color;
 $topbar-menu-icon-color:               $topbar-link-color;
 
-$topbar-height: 32px;
+$topbar-height: 2rem;
 $topbar-dropdown-toggle-color: $soft-accent-color;
 
 $masthead-bottom-accent-color:         $soft-accent-color;


### PR DESCRIPTION
Companion PR to https://github.com/dreamwidth/dw-free/pull/2556, which has all the spicy details. 

**Do not deploy these changes without free 2556.** They are incompatible with prior Foundation versions.