### PR TITLE
Tropospherical: Support `s2foundation` beta

### DIFF
--- a/htdocs/scss/skins/tropo/_tropo-base.scss
+++ b/htdocs/scss/skins/tropo/_tropo-base.scss
@@ -38,7 +38,9 @@ $header-height: 7em;
     margin: 0;
     border-style: solid;
     border-width: 1em 0;
-    min-height: 100vh;
+    @supports (display: flex) { // exclude IE11 bc it can't handle min-height + flex-direction: column
+        min-height: 100vh;
+    }
 }
 
 #canvas, #page {
@@ -55,7 +57,7 @@ $header-height: 7em;
 }
 
 #content, #page {
-  flex: 1;
+  flex-grow: 1;
 }
 
 

--- a/styles/siteviews/themes.s2
+++ b/styles/siteviews/themes.s2
@@ -5,7 +5,7 @@ layerinfo redist_uniq = "siteviews/tropo-red";
 
 function Page::print_theme_stylesheet() {
     # Do not actually *print* any stylesheets here, but you can $*SITEVIEWS->need_res(...); here to pull in anything.
-    $*SITEVIEWS->need_res( "stc/siteviews/tropo-red.css" );
+    $*SITEVIEWS->need_res( {"group" => "jquery"}, "stc/siteviews/tropo-red.css" );
 }
 
 #NEWLAYER: siteviews/tropo-purple
@@ -15,6 +15,6 @@ layerinfo redist_uniq = "siteviews/tropo-purple";
 
 function Page::print_theme_stylesheet() {
     # Do not actually *print* any stylesheets here, but you can $*SITEVIEWS->need_res(...); here to pull in anything.
-    $*SITEVIEWS->need_res( "stc/siteviews/tropo-purple.css" );
+    $*SITEVIEWS->need_res( {"group" => "jquery"}, "stc/siteviews/tropo-purple.css" );
 }
 


### PR DESCRIPTION
This is a companion PR to https://github.com/dreamwidth/dw-free/pull/2586. (Prior to that PR, you can't pass an options hashref to the S2 siteviews version of need_res.)

There's also a fix for an unrelated IE11 bug in the Foundation version of Tropo.