### PR TITLE
[#2587] Remove image shrinking CSS from nonfree journal layouts

### DIFF
--- a/styles/sundaymorning/layout.s2
+++ b/styles/sundaymorning/layout.s2
@@ -780,22 +780,6 @@ $userpic_css
 }
 .comment-content { border-top: 1px transparent solid; } /* for firefox */
 
-/* Constrain image dimensions.
-    Job 1: Don't trash the layout sideways.
-    Job 2: Limit height to fit inside the viewport. Having to scroll to see a
-      portrait of someone is nonsense.
-    Job 3: Defend the native aspect ratio.
-    Job 4: Respect the width/height HTML attributes for scaling down OR up
-      (within the limits of the container), but if they conflict with the aspect
-      ratio, treat them as maximums and let the aspect ratio win. */
-.entry-content img, .comment-content img {
-    height: auto;
-    max-width: 100%;
-    max-height: 95vh;
-    object-fit: contain;
-    object-position: left;
-}
-
 .tag {
     font-weight: bold;
     text-align: left;

--- a/styles/transmogrified/layout.s2
+++ b/styles/transmogrified/layout.s2
@@ -780,22 +780,6 @@ function Page::print_default_stylesheet () {
     }
     .comment-content { border-top: 1px transparent solid; } /* for firefox */
 
-    /* Constrain image dimensions.
-        Job 1: Don't trash the layout sideways.
-        Job 2: Limit height to fit inside the viewport. Having to scroll to see a
-          portrait of someone is nonsense.
-        Job 3: Defend the native aspect ratio.
-        Job 4: Respect the width/height HTML attributes for scaling down OR up
-          (within the limits of the container), but if they conflict with the aspect
-          ratio, treat them as maximums and let the aspect ratio win. */
-    .entry-content img, .comment-content img {
-        height: auto;
-        max-width: 100%;
-        max-height: 95vh;
-        object-fit: contain;
-        object-position: left;
-    }
-
     .page-recent .journal-type-P.has-userpic.no-subject .entry-content,
     .page-day .journal-type-P.has-userpic.no-subject .entry-content {
         padding-top: 25px;


### PR DESCRIPTION
This is a companion to https://github.com/dreamwidth/dw-free/pull/2595 -- since
the image shrinking CSS is in a global snippet now, it doesn't need to be
duplicated in every journal style.