### PR TITLE
Add base font size for journal pages (entry, reply)

### DIFF
--- a/htdocs/scss/skins/tropo/_tropo-base.scss
+++ b/htdocs/scss/skins/tropo/_tropo-base.scss
@@ -30,6 +30,7 @@
  * @copyright       Copyright (c) 2009 by Dreamwidth Studios, LLC
  */
 
+$journal-content-font-size: 0.85rem;
 @import "skins/global-styles", "skins/nav", "skins/skiplink";
 $header-height: 7em;
 


### PR DESCRIPTION
An upcoming PR in -free lets site skins configure the base font size for journal-like content. On tropo, tradition says this should be smaller than the general base size of 16px. 

Setting this variable has no effect in the absence of the PR that consumes it, so it's safe to merge whenever. 