### PR TITLE
remove deadphrased string from index.bml.text.local

### DIFF
--- a/htdocs/index.bml.text.local
+++ b/htdocs/index.bml.text.local
@@ -19,8 +19,6 @@
 
 .create.join_dreamwidth.content.nopayments=Creating an account requires an invite code. (<a [[aopts]]>Why?</a>)
 
-.create.paymentlink=Make Payment
-
 .create.paymentlink2=Create Paid Account
 
 .create.use_code=Use Code


### PR DESCRIPTION
It was getting re-added and re-removed every time I ran texttool.pl.