### PR TITLE
Fix header display problems in Tropospherical skins

### DIFF
--- a/htdocs/scss/skins/tropo/tropo-purple.scss
+++ b/htdocs/scss/skins/tropo/tropo-purple.scss
@@ -163,6 +163,12 @@ $masthead-bottom-accent-color:         $primary-color;
 
 @import "skins/tropo/tropo-base";
 
+// Hack to keep spirals from going where they don't belong.
+.main-nav:not(.expanded),
+.main-nav li.name {
+    background: $soft-accent-color;
+}
+
 footer {
     background-color: $soft-accent-color;
 }

--- a/htdocs/scss/skins/tropo/tropo-purple.scss
+++ b/htdocs/scss/skins/tropo/tropo-purple.scss
@@ -151,6 +151,7 @@ $topbar-link-bg-active:                $strong-accent-color;
 $topbar-dropdown-bg:                   $topbar-bg;
 $topbar-dropdown-link-color:           $primary-text-color;
 $topbar-dropdown-link-bg:              $primary-color url($topbar-bgimage-hover) $topbar-bgimage-position;
+$topbar-dropdown-link-bg-hover:        $topbar-link-bg-hover;
 
 $topbar-menu-link-color:               $topbar-link-color;
 $topbar-menu-icon-color:               $topbar-link-color;

--- a/htdocs/scss/skins/tropo/tropo-red.scss
+++ b/htdocs/scss/skins/tropo/tropo-red.scss
@@ -150,6 +150,7 @@ $topbar-link-bg-active:                $primary-color;
 $topbar-dropdown-bg:                   $topbar-bg;
 $topbar-dropdown-link-color:           $primary-text-color;
 $topbar-dropdown-link-bg:              $soft-accent-color url($topbar-bgimage-hover) $topbar-bgimage-position;
+$topbar-dropdown-link-bg-hover:        $topbar-link-bg-hover;
 
 $topbar-menu-link-color:               $topbar-link-color;
 $topbar-menu-icon-color:               $topbar-link-color;


### PR DESCRIPTION
Fixes #2653 (in conjunction with https://github.com/dreamwidth/dw-free/pull/2703) 

There ended up being a straightforward explanation for why the hover colors broke. The spiral turds on mobile purple... I kind of suspect those have always been there, tbh.

<details><summary>Screenshots</summary>

"before" is what's on prod. 

### Before: purple mobile

<img width="335" alt="Screen Shot 2020-06-21 at Jun 21, 11 59PM 1" src="https://user-images.githubusercontent.com/484309/85258043-a2670a80-b41b-11ea-927b-0ab9ecbe6cea.png">
<img width="336" alt="Screen Shot 2020-06-21 at Jun 21, 11 59PM" src="https://user-images.githubusercontent.com/484309/85258044-a2ffa100-b41b-11ea-896f-56e23e3a91a7.png">

### After: purple mobile

<img width="337" alt="Screen Shot 2020-06-21 at Jun 21, 11 58PM 1" src="https://user-images.githubusercontent.com/484309/85258078-aeeb6300-b41b-11ea-9403-6a858303be3d.png">
<img width="335" alt="Screen Shot 2020-06-21 at Jun 21, 11 58PM" src="https://user-images.githubusercontent.com/484309/85258081-af83f980-b41b-11ea-8ddd-9519a60cc3a8.png">

### Before: hover colors

Hovering on top-level nav item: 

<img width="259" alt="Screen Shot 2020-06-22 at Jun 22, 12 00AM 1" src="https://user-images.githubusercontent.com/484309/85258122-c3c7f680-b41b-11ea-8ee6-4902c827e120.png">

Hovering on child item: 

<img width="222" alt="Screen Shot 2020-06-21 at Jun 21, 11 59PM 2" src="https://user-images.githubusercontent.com/484309/85258156-d2161280-b41b-11ea-8b64-8bc230cee97f.png">

### After: hover colors

Hovering on top-level item: 

<img width="234" alt="Screen Shot 2020-06-22 at Jun 22, 12 00AM" src="https://user-images.githubusercontent.com/484309/85258176-de01d480-b41b-11ea-988d-a3e3afeb99de.png">

<img width="261" alt="Screen Shot 2020-06-21 at Jun 21, 11 57PM" src="https://user-images.githubusercontent.com/484309/85258212-ee19b400-b41b-11ea-82bc-9d84481856c1.png">

Hovering on sub-item:

<img width="218" alt="Screen Shot 2020-06-21 at Jun 21, 11 58PM 2" src="https://user-images.githubusercontent.com/484309/85258200-e9550000-b41b-11ea-9be1-ad06812beadc.png">

<img width="227" alt="Screen Shot 2020-06-21 at Jun 21, 11 57PM 1" src="https://user-images.githubusercontent.com/484309/85258231-f7a31c00-b41b-11ea-9519-df175b4b6707.png">

</details>