### PR TITLE
[dw-free#2764] remove bml suffix from faqbrowse links in site configs

### DIFF
--- a/etc/config-local.pl.example
+++ b/etc/config-local.pl.example
@@ -97,7 +97,7 @@
     # if you define these, little help bubbles appear next to common
     # widgets to the URL you define:
     %HELPURL = (
-        paidaccountinfo => "https://www.dreamwidth.org/support/faqbrowse.bml?faqid=4",
+        paidaccountinfo => "https://www.dreamwidth.org/support/faqbrowse?faqid=4",
     );
 
     # Configuration for suggestions community & adminbot


### PR DESCRIPTION
Fixes string defined in etc/config-local.pl.example.