### PR TITLE
Tropos: reduce background brightness

### DIFF
--- a/htdocs/scss/skins/tropo/tropo-purple.scss
+++ b/htdocs/scss/skins/tropo/tropo-purple.scss
@@ -85,7 +85,7 @@ $base-line-height:  1.5;
 // We use these to control header font styles
 $header-font-family:                    Arial, sans-serif;
 $page-title-color:                      $primary-color;
-$header-font-color:                     lighten( $body-font-color, 20% );
+$header-font-color:                     lighten( $body-font-color, 10% );
 $list-side-margin:                      1em;
 
 // we want to base these on $body-font-color rather than the random variables they're based on

--- a/htdocs/scss/skins/tropo/tropo-purple.scss
+++ b/htdocs/scss/skins/tropo/tropo-purple.scss
@@ -38,7 +38,7 @@ $_dark-purple:      #3a155a;
 $_pink:             #f3d2fc;
 $_light-purple:     #d3afec;
 
-$_light-gray:       #f7f7f7;
+$_light-gray:       #f5f5f5;
 $_low-contrast-gray:#ddd;
 $_mid-gray:         #e9e9e9;
 $_dark-gray:        #636363;

--- a/htdocs/scss/skins/tropo/tropo-red.scss
+++ b/htdocs/scss/skins/tropo/tropo-red.scss
@@ -85,7 +85,7 @@ $base-line-height:  1.5;
 // We use these to control header font styles
 $header-font-family:                    Arial, sans-serif;
 $page-title-color:                      $primary-color;
-$header-font-color:                     lighten( $body-font-color, 20% );
+$header-font-color:                     lighten( $body-font-color, 10% );
 $list-side-margin:                      1em;
 
 // we want to base these on $body-font-color rather than the random variables they're based on

--- a/htdocs/scss/skins/tropo/tropo-red.scss
+++ b/htdocs/scss/skins/tropo/tropo-red.scss
@@ -38,7 +38,7 @@ $_dark-red:         #a42226; // background red
 $_pink:             #f4717a;
 $_light-pink:       #ffd8d8;
 
-$_light-gray:       #f7f7f7;
+$_light-gray:       #f5f5f5;
 $_low-contrast-gray:#ddd;
 $_mid-gray:         #e9e9e9;
 $_dark-gray:        #636363;


### PR DESCRIPTION
Changes to spacing on comment pages seem to cause an illusion that the new
`#f7f7f7` is brighter than the old `#f7f7f7`. Reduce brightness to compensate?